### PR TITLE
feat: show versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ LABEL maintainer="https://github.com/officel"
 ENV TERRAFORM_VERSION 0.12.20
 ENV PACKER_VERSION 1.5.1
 
-RUN apk --update add --no-cache ansible py3-pip openssh ca-certificates && \
+RUN apk --update add --no-cache ansible py3-pip openssh ca-certificates wget && \
     pip3 install --upgrade pip botocore boto3 awscli && \
     ansible-galaxy install Datadog.datadog
 
@@ -19,7 +19,9 @@ RUN wget https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER
     unzip ./packer_${PACKER_VERSION}_linux_amd64.zip -d /usr/local/bin/ && \
     rm -f ./packer_${PACKER_VERSION}_linux_amd64.zip
 
+COPY info.sh /info.sh
+
 WORKDIR /home
 
-CMD ["/usr/bin/ansible --version"]
+CMD ["/info.sh"]
 

--- a/info.sh
+++ b/info.sh
@@ -1,0 +1,36 @@
+#! /bin/sh
+
+echo "tapad versions"
+
+echo "----------"
+echo "\$PATH"
+echo $PATH
+
+echo "----------"
+echo "python -V"
+python -V
+
+echo "----------"
+echo "pip -V"
+pip -V
+
+echo "----------"
+echo "pip list"
+pip list
+
+echo "----------"
+echo "aws --version"
+aws --version
+
+echo "----------"
+echo "ansible --version"
+ansible --version
+
+echo "----------"
+echo "terraform version"
+terraform version
+
+echo "----------"
+echo "packer version"
+packer version
+


### PR DESCRIPTION
alpine で wget(busyboxの)を使うと SSL エラーになることがある
解決策は wget パッケージをインストールすることらしいのでいれておく
ansible --version から info.sh に置き換え、インストール済コードの
バージョンを出力するようにした